### PR TITLE
Generate online meeting link

### DIFF
--- a/shared/data/supabase.ts
+++ b/shared/data/supabase.ts
@@ -68,6 +68,9 @@ class SupabaseDataAccessor implements DataAccessor {
   }
 
   async createWorkshop(workshop: Workshop): Promise<Workshop> {
+    if (workshop.virtual) {
+      workshop.meeting_link = await api.generateMeetingLink(workshop.name)
+    }
     const { data, error } = await supabase.from("workshops").insert([workshop]);
     if (error) throw error;
     if (data) {
@@ -269,7 +272,7 @@ class SupabaseDataAccessor implements DataAccessor {
           workshop.user_id.toString(),
           user_id,
           slot,
-          "https://dummy.online.meeting/"
+          workshop.meeting_link
         )
         return true;
       }

--- a/shared/infra/api.ts
+++ b/shared/infra/api.ts
@@ -40,6 +40,13 @@ export interface InfrastructureAPI {
    * @returns A boolean representing the operation success
    */
   cancelSlotPostProcessing(slot_id: string): Promise<boolean>
+
+  /**
+   * Generates a URL for an online meeting
+   * @param meeting_name The meeting name
+   * @returns A join URL
+   */
+  generateMeetingLink(meeting_name: string): Promise<string>
 }
 
 export enum ActionTrigger {

--- a/shared/infra/aws.ts
+++ b/shared/infra/aws.ts
@@ -14,6 +14,7 @@ class AWSInfrastructureAPI implements InfrastructureAPI {
   private bookingCancellationEndpoint: string;
   private scheduleSlotPostProcessingEndpoint: string;
   private cancelSlotPostProcessingEndpoint: string;
+  private generateMeetingEndpoint: string;
   
   constructor(apiGatewayBaseUrl: string) {
     if (apiGatewayBaseUrl === "") {
@@ -24,6 +25,7 @@ class AWSInfrastructureAPI implements InfrastructureAPI {
     this.bookingCancellationEndpoint = `${apiGatewayBaseUrl}/bookingCancellation`
     this.scheduleSlotPostProcessingEndpoint = `${apiGatewayBaseUrl}/scheduleSlotPostProcessing`
     this.cancelSlotPostProcessingEndpoint = `${apiGatewayBaseUrl}/cancelSlotPostProcessing`
+    this.generateMeetingEndpoint = `${apiGatewayBaseUrl}/generateOnlineMeeting`
   }
 
   private axios_instance = axios.create({
@@ -52,7 +54,7 @@ class AWSInfrastructureAPI implements InfrastructureAPI {
     return
   }
 
-  async sendBookingConfirmations(host_user_id: string, attendee_user_id: string, slot: Slot, join_link: string): Promise<void> {
+  async sendBookingConfirmations(host_user_id: string, attendee_user_id: string, slot: Slot, join_link: string | undefined): Promise<void> {
     const host: Profile = await data.getProfile(host_user_id)
     const attendee: Profile = await data.getProfile(attendee_user_id)
     if (host && attendee) {
@@ -133,6 +135,20 @@ class AWSInfrastructureAPI implements InfrastructureAPI {
     }).catch((err) => {
       console.log("Failed to execute cancel slot post processing request")
       return false
+    })
+  }
+
+  async generateMeetingLink(meeting_name: string): Promise<string> {
+    const data = {
+      name: meeting_name
+    }
+    console.log(JSON.stringify(data))
+    return this.axios_instance.post(this.generateMeetingEndpoint, JSON.stringify(data)).then((response) => {
+      console.log(`Response ${response.status}: ${JSON.stringify(response.data)}`)
+      return (response.status == 200) ? response.data["message"] : null
+    }).catch((err) => {
+      console.log("Failed to generate an online meeting link", err)
+      return null
     })
   }
 }

--- a/shared/schemas.ts
+++ b/shared/schemas.ts
@@ -23,6 +23,7 @@ export interface Workshop {
   postcode?: string;
   city?: string;
   virtual: boolean;
+  meeting_link?: string;
 }
 
 export interface Profile {


### PR DESCRIPTION
This is achived via the infrastructure API. We have an endpoint that runs a lambda function which in turn generates an online meeting room via our business account.

The meeting url is stored in the database, the schema is updated in the wiki, and the link is wired into the transactional emails.

Closes #66 