### PR TITLE
Fix #129 - Allow users to edit descriptions of their workshops

### DIFF
--- a/components/Workshop/WorkshopListing.tsx
+++ b/components/Workshop/WorkshopListing.tsx
@@ -37,7 +37,7 @@ export default function WorkshopListing({
     <Stack>
       <WorkshopListingHeading workshop={workshop} host={host} user={user} />
       <WorkshopListingLocation workshop={workshop} />
-      <WorkshopListingDescription workshop={workshop} />
+      <WorkshopListingDescription workshop={workshop} user={user} />
       {userBooking ? (
         <WorkshopListingUserBooking
           workshop={workshop}

--- a/components/Workshop/WorkshopListingDescription.tsx
+++ b/components/Workshop/WorkshopListingDescription.tsx
@@ -40,14 +40,15 @@ export default function WorkshopListingDescription({ workshop, user }: IProps) {
   return (
     <>
     {editModeOn ? (
-      <Box display="flex" justifyContent="space-between" px={{base:"6", md:"16"}}>
+      <Box display="flex" justifyContent="space-between" px={{base:"6", md:"16"}} p="6"
+           borderBottomWidth="1px" borderBottomColor="gray.200" rounded="md">
         <FormControl
           isInvalid={description == null || description.length < 200}>
-          <FormLabel htmlFor="description" fontSize="md">
+          <Heading as="h2" size="md" pb="0.5em">
             Description
-          </FormLabel>
+          </Heading>
           <Flex direction={{ base: "column", sm: "row" }} justifyContent="space-between">
-            <Box w="100%" me="4">
+            <Box w="100%" me="4" pt="2">
               <Textarea
                 value = {description}
                 minH={"18em"}
@@ -101,28 +102,32 @@ export default function WorkshopListingDescription({ workshop, user }: IProps) {
       borderBottomColor="gray.200"
       p="6"
       rounded="md"
-      px={{ base: "6", md: "16" }}
+      px={{ base: "6", md: "16" }} 
       >
-      <Heading as="h2" size="md" pb="0.5em">
-          Description
-      </Heading>
-      <Box display="flex" justifyContent="space-between">
+      <Flex justifyContent={"space-between"} alignItems={"center"}>
+        <Heading as="h2" size="md" pb="0.5em">
+            Description
+        </Heading>
+        {isUserHost && 
+          <Button
+            rounded="full"
+            colorScheme="blackAlpha"
+            variant="outline"
+            rightIcon={<MdOutlineEdit />}
+            onClick={() => onEdit()}
+            size={{ base: "sm", sm: "md" }}
+            mr="3"
+            >
+            Edit
+          </Button>
+        }
+      </Flex>
+     
+      <Box display="flex" justifyContent="space-between" pt="2">
         <Text whiteSpace={"pre-wrap"} color={"gray.600"} fontSize={"14px"} lineHeight="6" w="100%">
           {workshop.description}
         </Text>
-        {isUserHost && 
-        <Button
-          rounded="full"
-          colorScheme="blackAlpha"
-          variant="outline"
-          rightIcon={<MdOutlineEdit />}
-          onClick={() => onEdit()}
-          size={{ base: "sm", sm: "md" }}
-          mr="3"
-          >
-          Edit
-        </Button>
-        }
+       
       </Box>
     </Box> )}
   </>

--- a/components/Workshop/WorkshopListingDescription.tsx
+++ b/components/Workshop/WorkshopListingDescription.tsx
@@ -2,6 +2,7 @@
 
 import React, {useState} from "react";
 import { Box, 
+         Flex,
          Heading, 
          Text, 
          FormControl, 
@@ -39,14 +40,14 @@ export default function WorkshopListingDescription({ workshop, user }: IProps) {
   return (
     <>
     {editModeOn ? (
-      <Box display="flex" justifyContent="space-between" p="16">
+      <Box display="flex" justifyContent="space-between" px={{base:"6", md:"16"}}>
         <FormControl
           isInvalid={description == null || description.length < 200}>
           <FormLabel htmlFor="description" fontSize="md">
             Description
           </FormLabel>
-          <Box display="flex" justifyContent="space-between">
-            <Box w="100%">
+          <Flex direction={{ base: "column", sm: "row" }} justifyContent="space-between">
+            <Box w="100%" me="4">
               <Textarea
                 value = {description}
                 minH={"18em"}
@@ -59,12 +60,12 @@ export default function WorkshopListingDescription({ workshop, user }: IProps) {
                 {`${200 - description.length}`} characters remaining
               </FormErrorMessage>
               ) : (
-              <FormHelperText>
+              <FormHelperText pb={{base:"2", sm:"0"}}>
                 Provide as much detail as possible
               </FormHelperText>
               )}
             </Box>
-            <Box w="auto" display="flex" flexDir="column">
+            <Flex direction={{base:"row", sm:"column"}} gap={{ base: "2", md: "4" }}>
               <Button
                 colorScheme="green"
                 rounded="full"
@@ -72,8 +73,9 @@ export default function WorkshopListingDescription({ workshop, user }: IProps) {
                 type="submit"
                 onClick={() => onSave()}
                 rightIcon={<MdOutlineSave />}
-                size={{ base: "xs", sm: "md" }}
-                mx="3" mb="3"
+                size={{ base: "sm", sm: "md" }}
+                w={{ base: "100%", sm: "auto" }}
+                mx="2"
               >
                 Save
               </Button>
@@ -83,13 +85,14 @@ export default function WorkshopListingDescription({ workshop, user }: IProps) {
                 variant="outline"
                 onClick={onCancel}
                 rightIcon={<MdOutlineCancel />}
-                size={{ base: "xs", sm: "md" }}
-                mx="3"
+                size={{ base: "sm", sm: "md" }}
+                w={{ base: "100%", sm: "auto" }}
+                mx="2"
                 >
                   Cancel
               </Button>
-            </Box>
-          </Box>
+            </Flex>
+          </Flex>
         </FormControl>
       </Box>
     ) : (
@@ -114,7 +117,7 @@ export default function WorkshopListingDescription({ workshop, user }: IProps) {
           variant="outline"
           rightIcon={<MdOutlineEdit />}
           onClick={() => onEdit()}
-          size={{ base: "xs", sm: "md" }}
+          size={{ base: "sm", sm: "md" }}
           mr="3"
           >
           Edit

--- a/components/Workshop/WorkshopListingDescription.tsx
+++ b/components/Workshop/WorkshopListingDescription.tsx
@@ -1,30 +1,127 @@
 "use client";
 
-import React from "react";
-import { Box, Heading, Stack, Text } from "@chakra-ui/react";
-import { Workshop } from "@schemas";
+import React, {useState} from "react";
+import { Box, 
+         Heading, 
+         Text, 
+         FormControl, 
+         FormLabel, 
+         FormErrorMessage,
+         FormHelperText,
+         Button,
+         Textarea } from "@chakra-ui/react";
+import { Workshop, User } from "@schemas";
+import { clientData } from "@data/supabase";
+import { MdOutlineCancel, MdOutlineEdit, MdOutlineSave } from "react-icons/md";
 
 interface IProps {
   workshop: Workshop;
+  user: User | null;
 }
 
-export default function WorkshopListingDescription({ workshop }: IProps) {
+export default function WorkshopListingDescription({ workshop, user }: IProps) {
+  
+  const [description, setDescription] = useState(workshop.description);
+  const [editModeOn, setEditModeOn] = useState(false);
+
+  const isUserHost = user?.id == workshop.user_id;
+  
+  async function onSave (){
+    workshop.description = description;
+    await clientData.updateWorkshop(workshop);
+    setEditModeOn(false);
+  }
+
+  const onEdit = () => setEditModeOn(true);
+  const onCancel = () => setEditModeOn(false);
+
+  
   return (
+    <>
+    {editModeOn ? (
+      <Box display="flex" justifyContent="space-between" p="16">
+        <FormControl
+          isInvalid={description == null || description.length < 200}>
+          <FormLabel htmlFor="description" fontSize="md">
+            Description
+          </FormLabel>
+          <Box display="flex" justifyContent="space-between">
+            <Box w="100%">
+              <Textarea
+                value = {description}
+                minH={"18em"}
+                isRequired={true}
+                onChange={(e) => setDescription(e.target.value)}
+              />
+              {description == null || description.length < 200 ? (
+              <FormErrorMessage>
+                At least 200 characters required,{" "}
+                {`${200 - description.length}`} characters remaining
+              </FormErrorMessage>
+              ) : (
+              <FormHelperText>
+                Provide as much detail as possible
+              </FormHelperText>
+              )}
+            </Box>
+            <Box w="auto" display="flex" flexDir="column">
+              <Button
+                colorScheme="green"
+                rounded="full"
+                variant="solid"
+                type="submit"
+                onClick={() => onSave()}
+                rightIcon={<MdOutlineSave />}
+                size={{ base: "xs", sm: "md" }}
+                mx="3" mb="3"
+              >
+                Save
+              </Button>
+              <Button
+                rounded="full"
+                colorScheme="blackAlpha"
+                variant="outline"
+                onClick={onCancel}
+                rightIcon={<MdOutlineCancel />}
+                size={{ base: "xs", sm: "md" }}
+                mx="3"
+                >
+                  Cancel
+              </Button>
+            </Box>
+          </Box>
+        </FormControl>
+      </Box>
+    ) : (
     <Box
-      borderBottomWidth={"1px"}
+      borderBottomWidth="1px"
       borderBottomColor="gray.200"
       p="6"
       rounded="md"
       px={{ base: "6", md: "16" }}
-    >
-      <Stack>
-        <Heading as="h2" size="md" pb="0.5em">
+      >
+      <Heading as="h2" size="md" pb="0.5em">
           Description
-        </Heading>
-        <Text whiteSpace={"pre-wrap"} color={"gray.600"} fontSize={"14px"} lineHeight="6">
+      </Heading>
+      <Box display="flex" justifyContent="space-between">
+        <Text whiteSpace={"pre-wrap"} color={"gray.600"} fontSize={"14px"} lineHeight="6" w="100%">
           {workshop.description}
         </Text>
-      </Stack>
-    </Box>
+        {isUserHost && 
+        <Button
+          rounded="full"
+          colorScheme="blackAlpha"
+          variant="outline"
+          rightIcon={<MdOutlineEdit />}
+          onClick={() => onEdit()}
+          size={{ base: "xs", sm: "md" }}
+          mr="3"
+          >
+          Edit
+        </Button>
+        }
+      </Box>
+    </Box> )}
+  </>
   );
 }

--- a/shared/data/data.ts
+++ b/shared/data/data.ts
@@ -45,6 +45,13 @@ export interface DataAccessor {
   createWorkshop(workshop: Workshop): Promise<Workshop>
 
   /**
+   * Updates given workshop
+   * @param workshop A workshop to update
+   * @return An updated workshop
+   */
+  updateWorkshop(workshop: Workshop): Promise<Workshop>
+
+  /**
    * Cancels a workshop with a given id
    * @param workshop_id An id of the workshop to cancel
    * @return A boolean representing the success of the method

--- a/shared/data/supabase.ts
+++ b/shared/data/supabase.ts
@@ -97,6 +97,18 @@ class SupabaseDataAccessor implements DataAccessor {
     }
   }
 
+  async updateWorkshop(workshop: Workshop): Promise<Workshop> {
+    const { data, error } = await this.client.from("workshop")
+      .upsert([workshop])
+      .select();
+    if (error) throw error;
+    if (data) {
+      return data[0] as Workshop;
+    } else {
+      throw Error(`Failed to update a workshop: ${JSON.stringify(workshop)}`);
+    }
+  }
+
   async filterAvailableWorkshops(filters: FilterProps): Promise<Workshop[]> {
     const query = this.client
       .from("workshop")


### PR DESCRIPTION
Users can now edit descriptions of their own workshops. 
- Added logic for updating workshops in database.
- Modified WorkshopListingDescription component to handle both displaying and editing the description.

Something to consider:
- New buttons are Edit, Save and Cancel. What should their colors be?