### PR TITLE
Migrate to using the new API

### DIFF
--- a/app/workshops/[wid]/page.tsx
+++ b/app/workshops/[wid]/page.tsx
@@ -17,14 +17,19 @@ export async function generateMetadata(
   const data = new SupabaseDataAccessor(supabase);
 
   const id = params.wid;
-  const workshop = await data.getWorkshop(id);
-
-  return {
-    title: `${workshop.name} | Voluntreee`,
-    openGraph: {
-      images: [`${process.env.NEXT_PUBLIC_S3_STATIC_RESOURCES_BASE_URL}/${workshop.category}_sm.png`],
-    },
-  };
+  try {
+    const workshop = await data.getWorkshop(id);
+    return {
+      title: `${workshop.name} | Voluntreee`,
+      openGraph: {
+        images: [`${process.env.NEXT_PUBLIC_S3_STATIC_RESOURCES_BASE_URL}/${workshop.category}_sm.png`],
+      },
+    };
+  } catch (err) {
+    return {
+      title: `Voluntreee`
+    };
+  }
 }
 
 export default async function Page({ params }: Props) {

--- a/shared/data/data.ts
+++ b/shared/data/data.ts
@@ -38,6 +38,12 @@ export interface DataAccessor {
   getProfile(id: string): Promise<Profile>
 
   /**
+   * Gets a JWT token for the currently logged in user
+   * @return A JWT token if a user is logged in
+   */
+  getJWT(): Promise<string|undefined>
+
+  /**
    * Creates given workshop
    * @param workshop A workshop to create
    * @return A created workshop

--- a/shared/infra/api.ts
+++ b/shared/infra/api.ts
@@ -1,54 +1,45 @@
-import { Slot } from "@schemas"
+import { BookingDetails, Slot, Workshop } from "@schemas"
 
 export interface InfrastructureAPI {
   /**
    * Sends a workshop creation confirmation email to the host 
-   * @param host_user_id A host user id
-   * @param workshop_name A workshop name
+   * @param workshop Workshop details
    */
-  sendWorkshopCreationConfirmation(host_user_id: string, workshop_name: string): Promise<void>
+  workshopConfirmation(workshop: Workshop): Promise<void>
 
   /**
    * Sends a booking confirmation email to both the host and the attendee
-   * @param host_user_id A host user id
-   * @param attendee_user_id An attendee user id
-   * @param workshop_name A workshop name
-   * @param slot Booked slot
-   * @param join_link A link to the 
+   * @param booking A booking to be confirmed
    */
-  sendBookingConfirmations(host_user_id: string, attendee_user_id: string, workshop_name: string, slot: Slot, join_link: string): Promise<void>
+  bookingConfirmation(booking: BookingDetails): Promise<void>
 
   /**
    * Sends a booking cancellation email to both the host and the attendee
-   * @param host_user_id A host user id
-   * @param attendee_user_id An attendee user id
-   * @param workshop_name A workshop name
-   * @param slot Slot to cancel
+   * @param booking A booking to be cancelled
    * @param triggered_by Action triggered by
    */
-  sendBookingCancellations(host_user_id: string, attendee_user_id: string, workshop_name: string, slot: Slot, triggered_by: ActionTrigger): Promise<void>
+  bookingCancellation(booking: BookingDetails, triggered_by: ActionTrigger): Promise<void>
 
   /**
    * Schedule a slot post processing event
-   * @param slot_id A slot id for which the post processing is to be scheduled
-   * @param slot_end_timestamp A timestamp of when the slot finishes in YYYY-MM-DD'T'HH:mm:ss format
+   * @param slot A slot for which the post processing is to be scheduled
    * @returns A boolean representing the operation success
    */
-  scheduleSlotPostProcessing(slot_id: string, slot_end_timestamp: string): Promise<boolean>
+  scheduleSlotPostProcessing(slot: Slot): Promise<boolean>
 
   /**
    * Cancel a slot post processing event
-   * @param slot_id A slot id for which the post processing is to be cancelled
+   * @param slot A slot for which the post processing is to be cancelled
    * @returns A boolean representing the operation success
    */
-  cancelSlotPostProcessing(slot_id: string): Promise<boolean>
+  cancelSlotPostProcessing(slot: Slot): Promise<boolean>
 
   /**
    * Generates a URL for an online meeting
-   * @param meeting_name The meeting name
+   * @param workshop The meeting for which to generate the meeting link
    * @returns A join URL
    */
-  generateMeetingLink(meeting_name: string): Promise<string>
+  generateMeetingLink(workshop: Workshop): Promise<string>
 }
 
 export enum ActionTrigger {


### PR DESCRIPTION
The new API is deployed through IaC via the [api repo](https://github.com/voluntree-uk/api)
It has authentication enabled using supabase JWT token verification
Endpoints have also changed so I took a chance to clean up the code in the app 

To run this locally, you need to update the API pointer in environment variables:
```NEXT_PUBLIC_AWS_GATEWAY_BASE_URL=https://pgzs9ivhlj.execute-api.eu-west-2.amazonaws.com/dev```
